### PR TITLE
Allow Array type for generic types.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -14,7 +14,10 @@
       "variable-declaration",
       "member-variable-declaration"
     ],
-    "max-line-length": [true, 120],
+    "max-line-length": [
+      true,
+      120
+    ],
     "member-ordering": [
       true,
       {
@@ -58,9 +61,18 @@
     "no-invalid-this": true,
     "no-default-export": true,
     "arrow-parens": true,
-    "interface-name": [true, "never-prefix"],
+    "interface-name": [
+      true,
+      "never-prefix"
+    ],
     "prefer-function-over-method": true,
-    "align": false
+    "align": false,
+    "prefer-array-literal": [
+      true,
+      {
+        "allow-type-parameters": true
+      }
+    ]
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
There are two interfering TSLint rules:
 - array-type (TSLint built-in)
 - prefer-array-literal (tslint-microsoft-contrib)

## Now

`name:Array<GenericType<string>>` causes:
```
Replace generic-typed Array with array literal: Array<GenericType<number>> (prefer-array-literal)
```
and `name:GenericType<string>[]` causes:
```
Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead. (array-type)
```

## After merge of this change
Valid types:
 - `string[]`
 - `SomeType[]`
 - `Array<GenericType<string>>`

Invalid types:
 - `Array<string>`
 - `Array<SomeType>`
 - `GenericType<string>[]`