### PR TITLE
Allow parentheses around single function argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-uxpin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "UXPin TypeScript Style Guide",
   "keywords": [
     "tslint",

--- a/tslint.json
+++ b/tslint.json
@@ -61,6 +61,7 @@
     "no-invalid-this": true,
     "no-default-export": true,
     "arrow-parens": true,
+    "ter-arrow-parens": true,
     "interface-name": [
       true,
       "never-prefix"


### PR DESCRIPTION
Before the change 
```javascript
[1].map((num) => console.log(num));
```

had thrown an error
```
Unexpected parentheses around single function argument having a body with no curly braces.
```