### PR TITLE
Disabled rule `object-shorthand-properties-first`

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -73,7 +73,8 @@
       {
         "allow-type-parameters": true
       }
-    ]
+    ],
+    "object-shorthand-properties-first": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Disabled rule `object-shorthand-properties-first` to avoid conflicting with `object-literal-sort-keys`