### PR TITLE
Overridden "space-before-function-paren"

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -86,9 +86,9 @@
         "asyncArrow": "always",
         "constructor": "never",
         "method": "never",
-        "named": "never",
-      },
-    ],
+        "named": "never"
+      }
+    ]
   },
   "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -78,7 +78,17 @@
       }
     ],
     "object-shorthand-properties-first": false,
-    "strict-boolean-expressions": false
+    "strict-boolean-expressions": false,
+    "space-before-function-paren": [
+      true,
+      {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never",
+      },
+    ],
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Do not allow space before anonymous function

TSLint was forcing to writhe
```
const myFunc = function () {};
```
instead of
```
const myFunc = function() {};
```